### PR TITLE
Fix Lambda read-only filesystem for centralized logging

### DIFF
--- a/src/core/logging_config.py
+++ b/src/core/logging_config.py
@@ -3,7 +3,9 @@ import logging
 import os
 from logging.handlers import RotatingFileHandler
 
-LOGS_DIR = "logs"
+# Use /tmp for Lambda/cloud environments (read-only filesystem)
+# FastMCP Cloud runs on AWS Lambda with Lambda Web Adapter
+LOGS_DIR = os.getenv("LOGS_DIR", "/tmp" if os.getenv("AWS_LAMBDA_FUNCTION_NAME") else "logs")
 LOG_FILENAME = os.path.join(LOGS_DIR, "app.log")
 
 # Create a filter to allow specific loggers' INFO messages to show in console


### PR DESCRIPTION
FastMCP Cloud runs on AWS Lambda with Lambda Web Adapter, which has a read-only filesystem except /tmp directory.

Changes:
- Detect Lambda via AWS_LAMBDA_FUNCTION_NAME environment variable
- Use /tmp for logs in Lambda, logs/ for local development
- Maintains compatibility with local development workflow
- Fixes: [Errno 30] Read-only file system: '/app/logs/app.log'

Best Practice:
- Lambda captures console output → CloudWatch automatically
- File logging in /tmp works but has limited persistence
- This is minimal fix for FastMCP Cloud compatibility

References:
- FastMCP Cloud uses Lambda Web Adapter
- AWS Lambda best practices recommend console logging
- /tmp has 512MB limit and ephemeral storage